### PR TITLE
[fix] export unions

### DIFF
--- a/src/renderers/contentful/renderDefaultLocale.ts
+++ b/src/renderers/contentful/renderDefaultLocale.ts
@@ -7,5 +7,5 @@ export default function renderDefaultLocale(locales: Locale[]): string {
     throw new Error("Could not find a default locale in Contentful.")
   }
 
-  return `type CONTENTFUL_DEFAULT_LOCALE_CODE = '${defaultLocale.code}';`
+  return `export type CONTENTFUL_DEFAULT_LOCALE_CODE = '${defaultLocale.code}';`
 }

--- a/src/renderers/typescript/renderUnion.ts
+++ b/src/renderers/typescript/renderUnion.ts
@@ -1,6 +1,6 @@
 export default function renderUnion(name: string, values: string[]): string {
   return `
-    type ${name} = ${renderUnionValues(values)};
+    export type ${name} = ${renderUnionValues(values)};
   `
 }
 

--- a/test/renderers/contentful/renderAllLocales.test.ts
+++ b/test/renderers/contentful/renderAllLocales.test.ts
@@ -22,7 +22,7 @@ describe("renderSymbol()", () => {
 
   it("works with a list of locales", () => {
     expect(format(renderAllLocales(locales))).toMatchInlineSnapshot(
-      `"type LOCALE_CODE = \\"en-US\\" | \\"pt-BR\\";"`,
+      `"export type LOCALE_CODE = \\"en-US\\" | \\"pt-BR\\";"`,
     )
   })
 })

--- a/test/renderers/contentful/renderDefaultLocale.test.ts
+++ b/test/renderers/contentful/renderDefaultLocale.test.ts
@@ -22,7 +22,7 @@ describe("renderSymbol()", () => {
 
   it("works with a list of locales", () => {
     expect(format(renderDefaultLocale(locales))).toMatchInlineSnapshot(
-      `"type CONTENTFUL_DEFAULT_LOCALE_CODE = \\"en-US\\";"`,
+      `"export type CONTENTFUL_DEFAULT_LOCALE_CODE = \\"en-US\\";"`,
     )
   })
 

--- a/test/renderers/render.test.ts
+++ b/test/renderers/render.test.ts
@@ -80,11 +80,11 @@ describe("render()", () => {
         }
       }
 
-      type CONTENT_TYPE = \\"myContentType\\"
+      export type CONTENT_TYPE = \\"myContentType\\"
 
-      type LOCALE_CODE = \\"en-US\\" | \\"pt-BR\\"
+      export type LOCALE_CODE = \\"en-US\\" | \\"pt-BR\\"
 
-      type CONTENTFUL_DEFAULT_LOCALE_CODE = \\"en-US\\"
+      export type CONTENTFUL_DEFAULT_LOCALE_CODE = \\"en-US\\"
       "
     `)
   })

--- a/test/renderers/typescript/renderUnion.test.ts
+++ b/test/renderers/typescript/renderUnion.test.ts
@@ -4,7 +4,7 @@ import format from "../../support/format"
 describe("renderUnion()", () => {
   it("renders a union", () => {
     expect(format(renderUnion("name", ["1", "2", "3"]))).toMatchInlineSnapshot(
-      `"type name = 1 | 2 | 3;"`,
+      `"export type name = 1 | 2 | 3;"`,
     )
   })
 })


### PR DESCRIPTION
Unions should be exported along with interfaces

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zernie/contentful-typescript-codegen/1)
<!-- Reviewable:end -->
